### PR TITLE
Add the ability to parse if json or plainText without extra configs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- JSON detection to handle JSON or non-JSON SecretStrings
 
 ## [2.1.0] - 2022-03-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Specify the list of secrets to be fetched, under the `secret_list` input, with e
 <Secret ARN> # <JSON object key> # <Environment variable>
 ```
 
-For example, given the secret with an ARN `arn:aws:secret-1`, and a secret value:
+If your SecretString is not JSON, the `<JSON object key>` can be omitted with `_`. See the PlainText SecretString example below for more details.
+
+### JSON SecretString Example
+For example, if the given the secret is JSON with an ARN `arn:aws:secret-1`, and a secret value:
 
 ```json
 {
@@ -53,7 +56,23 @@ Specifying this line in the secret list:
 arn:aws:secret-1 # username # USERNAME
 ```
 
-Fetches the secret, retrieves the JSON value under the key `username`, and store that value in the `USERNAME` environment variable. `$USERNAME` will now contain the value `admin`.
+Fetches the secret, retrieves the JSON value under the key `username`, and stores that value in the `USERNAME` environment variable. `$USERNAME` will now contain the value `admin`.
+
+
+### PlainText SecretString Example
+If the given secret is plain text (not JSON) with an ARN `arn:aws:secret-1`, and the secret value:
+
+```
+SOME_SECRET_VALUE
+```
+
+Specifying this line in the secret list:
+
+```
+arn:aws:secret-1 # username # USERNAME
+```
+
+The key `username` is ignored and can be omitted with `_`. Fetches the secret, retrieves the value, and stores that value in the `USERNAME` environment variable. `$USERNAME` will now contain the value `SOME_SECRET_VALUE`.
 
 ### Authenticating with AWS
 

--- a/step.yml
+++ b/step.yml
@@ -5,6 +5,8 @@ description: |
 
   The fetched secrets are then propagated into subsequent steps in the workflow.
 
+  This step can detect if it should parse the SecretString as JSON or as regular text. No extra configuration required.
+
   Include this Step in your workflow, for example:
 
   ```yaml


### PR DESCRIPTION
This allows the step to handle JSON or plain string values in the
SecretString. No configuration required.

This solves issue #4.

Includes modifications to the README to discuss JSON and Non-JSON
examples.

Includes changes under the Unreleased section in CHANGELOG